### PR TITLE
feat: add goreleaser and musl support

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -2,7 +2,12 @@
 set -u
 
 REPOSITORY="authelia/crossbuild"
-TAG="latest"
+
+if [[ ${BUILDKITE_BRANCH} == "master" ]]; then
+  TAG="latest"
+else
+  TAG=${BUILDKITE_BRANCH}
+fi
 
 cat << EOF
 steps:
@@ -13,11 +18,21 @@ steps:
     concurrency_group: "crossbuild-deployments"
     agents:
       upload: "fast"
+    if: build.branch == "master"
+
+  - label: ":docker: Build and Deploy"
+    commands:
+      - "docker build --tag ${REPOSITORY}:${TAG} --provenance mode=max,reproducible=true --sbom true --builder buildx --progress plain --pull --push ."
+    agents:
+      upload: "fast"
+    if: build.branch != "master"
 
   - wait:
+    if: build.branch == "master"
 
   - label: ":docker: Update README.md"
     command: "curl \"https://ci.nerv.com.au/readmesync/update?github_repo=${REPOSITORY}&dockerhub_repo=${REPOSITORY}\""
     agents:
       upload: "fast"
+    if: build.branch == "master"
 EOF

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN <<EOF
   for triple in $(echo ${MUSL_TRIPLES} | tr "," " "); do
     make TARGET=${triple} OUTPUT=/usr GCC_VER=${GCC_VERSION} LINUX_VER=${LINUX_VERSION} install
   done
-  cd tmp && rm -rf /tmp/*
+  cd /tmp && rm -rf /tmp/*
 EOF
 
 ARG GNU_MIRROR="https://mirrors.middlendian.com/gnu"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,154 +1,180 @@
 FROM buildpack-deps:oldstable-curl
-LABEL maintainer="Nightah"
+LABEL org.opencontainers.image.authors="Authelia Team <team@authelia.com>"
 
-ENV CROSS_TRIPLE="x86_64-linux-gnu" \
-    PATH="/root/go/bin:/usr/local/go/bin:$PATH" \
-    LD_LIBRARY_PATH="/usr/x86_64-pc-freebsd14/lib:$LD_LIBRARY_PATH" \
-    GOROOT="/usr/local/go" \
-    CGO_CPPFLAGS="-D_FORTIFY_SOURCE=2 -fstack-protector-strong" \
-    CGO_LDFLAGS="-Wl,-z,relro,-z,now"
+ENV \
+  CGO_CPPFLAGS="-D_FORTIFY_SOURCE=2 -fstack-protector-strong" \
+  CGO_LDFLAGS="-Wl,-z,relro,-z,now" \
+  CROSS_TRIPLE="x86_64-linux-gnu" \
+  GOROOT="/usr/local/go" \
+  LD_LIBRARY_PATH="/usr/x86_64-pc-freebsd14/lib:$LD_LIBRARY_PATH" \
+  PATH="/root/go/bin:/usr/local/go/bin:$PATH"
 
-# Install deps
-RUN set -x; echo "Starting image build for Debian oldstable" \
- && dpkg --add-architecture arm64                      \
- && dpkg --add-architecture armhf                      \
- && apt-get update                                     \
- && apt-get install -y -q                              \
-        autoconf                                       \
-        automake                                       \
-        autotools-dev                                  \
-        binutils-multiarch                             \
-        binutils-multiarch-dev                         \
-        build-essential                                \
-        ccache                                         \
-        crossbuild-essential-arm64                     \
-        crossbuild-essential-armhf                     \
-        curl                                           \
-        git-core                                       \
-        multistrap                                     \
-        wget                                           \
-        xz-utils                                       \
-        libxml2-dev                                    \
-        lzma-dev                                       \
-        openssl                                        \
-        libssl-dev                                     \
- && apt-get clean
-
-ARG GNU_MIRROR="https://mirrors.middlendian.com/gnu"
-
-ARG FREEBSD_VERSION="14.3"
-ARG FREEBSD_PREFIX="x86_64-pc-freebsd14"
-
-ARG BINUTILS_VERSION="2.44"
-
-ARG GMP_VERSION="6.3.0"
-
-ARG MPFR_VERSION="4.2.2"
-
-ARG MPC_VERSION="1.3.1"
+RUN <<EOF
+  echo "Starting image build for Debian oldstable"
+  echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' > /etc/apt/sources.list.d/goreleaser.list
+  dpkg --add-architecture arm64
+  dpkg --add-architecture armhf
+  apt-get update
+  apt-get install -y -q \
+    autoconf \
+    automake \
+    autotools-dev \
+    binutils-multiarch \
+    binutils-multiarch-dev \
+    build-essential \
+    ccache \
+    crossbuild-essential-arm64 \
+    crossbuild-essential-armhf \
+    curl \
+    git-core \
+    goreleaser \
+    libssl-dev \
+    libxml2-dev \
+    lzma-dev \
+    multistrap \
+    openssl \
+    wget \
+    xz-utils
+  apt-get -y clean
+EOF
 
 ARG GCC_VERSION="15.1.0"
+ARG LINUX_VERSION="5.8.5"
+ARG MUSL_TRIPLES="x86_64-linux-musl,aarch64-linux-musl,arm-linux-musleabihf"
 
-# Install FreeBSD cross-tools
-# Compile binutils
-RUN cd /tmp && \
-  wget ${GNU_MIRROR}/binutils/binutils-${BINUTILS_VERSION}.tar.gz && \
-  tar xf binutils-${BINUTILS_VERSION}.tar.gz && \
-  cd binutils-${BINUTILS_VERSION} && \
+RUN <<EOF
+  cd /tmp
+  git clone https://github.com/richfelker/musl-cross-make
+  cd musl-cross-make
+  for triple in $(echo ${MUSL_TRIPLES} | tr "," " "); do
+    make TARGET=${triple} OUTPUT=/usr GCC_VER=${GCC_VERSION} LINUX_VER=${LINUX_VERSION} install
+  done
+  cd tmp && rm -rf /tmp/*
+EOF
+
+ARG GNU_MIRROR="https://mirrors.middlendian.com/gnu"
+ARG FREEBSD_VERSION="14.3"
+ARG FREEBSD_PREFIX="x86_64-pc-freebsd14"
+ARG BINUTILS_VERSION="2.44"
+ARG GMP_VERSION="6.3.0"
+ARG MPFR_VERSION="4.2.2"
+ARG MPC_VERSION="1.3.1"
+
+RUN <<EOF
+  cd /tmp
+  wget ${GNU_MIRROR}/binutils/binutils-${BINUTILS_VERSION}.tar.gz
+  tar xf binutils-${BINUTILS_VERSION}.tar.gz
+  cd binutils-${BINUTILS_VERSION}
   ./configure --enable-libssp --enable-gold --enable-ld \
-  --target=${FREEBSD_PREFIX} --prefix=/usr/${FREEBSD_PREFIX} --bindir=/usr/bin && \
-  make -j4 && \
-  make install && \
+  --target=${FREEBSD_PREFIX} --prefix=/usr/${FREEBSD_PREFIX} --bindir=/usr/bin
+  make -j4
+  make install
   cd /tmp && rm -rf /tmp/*
-# Get FreeBSD libs/headers
-RUN cd /tmp && \
-  wget https://mirror.aarnet.edu.au/pub/FreeBSD/releases/amd64/${FREEBSD_VERSION}-RELEASE/base.txz && \
-  cd /usr/${FREEBSD_PREFIX}/${FREEBSD_PREFIX} && \
-  tar -xf /tmp/base.txz ./lib/ ./usr/lib/ ./usr/include/ && \
-  cd /usr/${FREEBSD_PREFIX}/${FREEBSD_PREFIX}/usr/lib && \
+EOF
+
+RUN <<EOF
+  cd /tmp
+  wget https://mirror.aarnet.edu.au/pub/FreeBSD/releases/amd64/${FREEBSD_VERSION}-RELEASE/base.txz
+  cd /usr/${FREEBSD_PREFIX}/${FREEBSD_PREFIX}
+  tar -xf /tmp/base.txz ./lib/ ./usr/lib/ ./usr/include/
+  cd /usr/${FREEBSD_PREFIX}/${FREEBSD_PREFIX}/usr/lib
   find . -xtype l|xargs ls -l|grep ' /lib/' \
   | awk '{print "ln -sf /usr/x86_64-pc-freebsd14/x86_64-pc-freebsd14"$11 " " $9}' \
-  | /bin/sh && \
+  | /bin/sh
   cd /tmp && rm -rf /tmp/*
-# Compile GMP
-RUN cd /tmp && \
-  wget ${GNU_MIRROR}/gmp/gmp-${GMP_VERSION}.tar.xz && \
-  tar -xf gmp-${GMP_VERSION}.tar.xz && \
-  cd gmp-${GMP_VERSION} && \
+EOF
+
+RUN <<EOF
+  cd /tmp
+  wget ${GNU_MIRROR}/gmp/gmp-${GMP_VERSION}.tar.xz
+  tar -xf gmp-${GMP_VERSION}.tar.xz
+  cd gmp-${GMP_VERSION}
   ./configure --prefix=/usr/${FREEBSD_PREFIX} --bindir=/usr/bin --enable-shared --enable-static \
-  --enable-fft --enable-cxx --host=${FREEBSD_PREFIX} && \
-  make -j4 && make install && \
+  --enable-fft --enable-cxx --host=${FREEBSD_PREFIX}
+  make -j4 && make install
   cd /tmp && rm -rf /tmp/*
-# Compile MPFR
-RUN cd /tmp && \
-  wget ${GNU_MIRROR}/mpfr/mpfr-${MPFR_VERSION}.tar.xz && tar -xf mpfr-${MPFR_VERSION}.tar.xz && \
-  cd mpfr-${MPFR_VERSION} && \
+EOF
+
+RUN <<EOF
+  cd /tmp
+  wget ${GNU_MIRROR}/mpfr/mpfr-${MPFR_VERSION}.tar.xz && tar -xf mpfr-${MPFR_VERSION}.tar.xz
+  cd mpfr-${MPFR_VERSION}
   ./configure --prefix=/usr/${FREEBSD_PREFIX} --bindir=/usr/bin --with-gnu-ld--enable-static \
-  --enable-shared --with-gmp=/usr/${FREEBSD_PREFIX} --host=${FREEBSD_PREFIX} && \
-  make -j4 && make install && \
+  --enable-shared --with-gmp=/usr/${FREEBSD_PREFIX} --host=${FREEBSD_PREFIX}
+  make -j4 && make install
   cd /tmp && rm -rf /tmp/*
-# Compile MPC
-RUN cd /tmp && \
-  wget ${GNU_MIRROR}/mpc/mpc-${MPC_VERSION}.tar.gz && tar -xf mpc-${MPC_VERSION}.tar.gz && \
-  cd mpc-${MPC_VERSION} && \
+EOF
+
+RUN <<EOF
+  cd /tmp
+  wget ${GNU_MIRROR}/mpc/mpc-${MPC_VERSION}.tar.gz && tar -xf mpc-${MPC_VERSION}.tar.gz
+  cd mpc-${MPC_VERSION}
   ./configure --prefix=/usr/${FREEBSD_PREFIX} --bindir=/usr/bin --with-gnu-ld --enable-static \
   --enable-shared --with-gmp=/usr/${FREEBSD_PREFIX} \
-  --with-mpfr=/usr/${FREEBSD_PREFIX} --host=${FREEBSD_PREFIX} && \
-  make -j4 && make install && \
+  --with-mpfr=/usr/${FREEBSD_PREFIX} --host=${FREEBSD_PREFIX}
+  make -j4 && make install
   cd /tmp && rm -rf /tmp/*
-# Compile GCC
-RUN cd /tmp && \
-  wget ${GNU_MIRROR}/gcc/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.xz && \
-  tar xf gcc-${GCC_VERSION}.tar.xz && \
-  cd gcc-${GCC_VERSION} && mkdir build && cd build && \
+EOF
+
+RUN <<EOF
+  cd /tmp
+  wget ${GNU_MIRROR}/gcc/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.xz
+  tar xf gcc-${GCC_VERSION}.tar.xz
+  cd gcc-${GCC_VERSION}
+  mkdir build
+  cd build
   ../configure --without-headers --with-gnu-as --with-gnu-ld --disable-nls \
   --enable-languages=c,c++ --enable-libssp --enable-gold --enable-ld \
   --disable-libitm --disable-libquadmath --disable-multilib --target=${FREEBSD_PREFIX} \
   --prefix=/usr/${FREEBSD_PREFIX} --bindir=/usr/bin --with-gmp=/usr/${FREEBSD_PREFIX} \
   --with-mpc=/usr/${FREEBSD_PREFIX} --with-mpfr=/usr/${FREEBSD_PREFIX} --disable-libgomp \
   --with-sysroot=/usr/${FREEBSD_PREFIX}/${FREEBSD_PREFIX} \
-  --with-build-sysroot=/usr/${FREEBSD_PREFIX}/${FREEBSD_PREFIX} && \
-  cd /tmp/gcc-${GCC_VERSION} && \
-  cd /tmp/gcc-${GCC_VERSION}/build && \
-  make -j4 && make install && \
+  --with-build-sysroot=/usr/${FREEBSD_PREFIX}/${FREEBSD_PREFIX}
+  cd /tmp/gcc-${GCC_VERSION}/build
+  make -j4 && make install
   cd /tmp && rm -rf /tmp/*
+EOF
 
-ARG LINUX_TRIPLES="arm-linux-gnueabihf,aarch64-linux-gnu"
-# Create symlinks for triples
-RUN for triple in $(echo ${LINUX_TRIPLES} | tr "," " "); do                                       \
-      for bin in /usr/bin/$triple-*; do                                                           \
-        if [ ! -f /usr/$triple/bin/$(basename $bin | sed "s/$triple-//") ]; then                  \
-          ln -s $bin /usr/$triple/bin/$(basename $bin | sed "s/$triple-//");                      \
-        fi;                                                                                       \
-      done;                                                                                       \
-      for bin in /usr/bin/$triple-*; do                                                           \
-        if [ ! -f /usr/$triple/bin/cc ]; then                                                     \
-          ln -s gcc /usr/$triple/bin/cc;                                                          \
-        fi;                                                                                       \
-      done;                                                                                       \
-    done &&                                                                                       \
-    for triple in $(echo ${FREEBSD_PREFIX} | tr "," " "); do                                     \
-      mkdir -p /usr/$triple/bin;                                                                  \
-      for bin in /usr/bin/$triple-*; do                                                           \
-        if [ ! -f /usr/$triple/bin/$(basename $bin | sed "s/$triple-//") ]; then                  \
-          ln -s $bin /usr/$triple/bin/$(basename $bin | sed "s/$triple-//");                      \
-        fi;                                                                                       \
-      done;                                                                                       \
-      ln -s gcc /usr/$triple/bin/cc;                                                              \
+ARG GLIBC_TRIPLES="arm-linux-gnueabihf,aarch64-linux-gnu"
+
+RUN <<EOF
+  for triple in $(echo ${GLIBC_TRIPLES} | tr "," " "); do
+    for bin in /usr/bin/$triple-*; do
+      if [ ! -f /usr/$triple/bin/$(basename $bin | sed "s/$triple-//") ]; then
+        ln -s $bin /usr/$triple/bin/$(basename $bin | sed "s/$triple-//")
+      fi
     done
+    for bin in /usr/bin/$triple-*; do
+      if [ ! -f /usr/$triple/bin/cc ]; then
+        ln -s gcc /usr/$triple/bin/cc
+      fi
+    done
+  done
+  for triple in $(echo ${FREEBSD_PREFIX} | tr "," " "); do
+    mkdir -p /usr/$triple/bin
+    for bin in /usr/bin/$triple-*; do
+      if [ ! -f /usr/$triple/bin/$(basename $bin | sed "s/$triple-//") ]; then
+        ln -s $bin /usr/$triple/bin/$(basename $bin | sed "s/$triple-//")
+      fi
+    done
+    ln -s gcc /usr/$triple/bin/cc
+  done
+EOF
 
-ARG GO_VERSION="1.24.4"
-# Install Golang and gox
-RUN cd /tmp && \
-  wget https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz && \
-  tar -xvf go${GO_VERSION}.linux-amd64.tar.gz && \
-  mv go /usr/local/ && \
-  go install github.com/authelia/gox@latest && \
-  git config --global --add safe.directory /workdir && \
+ARG GO_VERSION="1.25.0"
+
+RUN <<EOF
+  cd /tmp
+  wget https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz
+  tar -xvf go${GO_VERSION}.linux-amd64.tar.gz
+  mv go /usr/local/
+  go install github.com/authelia/gox@latest
+  git config --global --add safe.directory /workdir
   rm -rf /tmp/*
+EOF
 
-# Image metadata
+COPY --link ./assets/crossbuild /usr/bin/crossbuild
+
 ENTRYPOINT ["/usr/bin/crossbuild"]
 CMD ["/bin/bash"]
 WORKDIR /workdir
-COPY ./assets/crossbuild /usr/bin/crossbuild

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM buildpack-deps:oldstable-curl
 LABEL org.opencontainers.image.authors="Authelia Team <team@authelia.com>"
+LABEL org.authelia.image.prune.protection="true"
 
 ENV \
   CGO_CPPFLAGS="-D_FORTIFY_SOURCE=2 -fstack-protector-strong" \
@@ -168,7 +169,6 @@ RUN <<EOF
   wget https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz
   tar -xvf go${GO_VERSION}.linux-amd64.tar.gz
   mv go /usr/local/
-  go install github.com/authelia/gox@latest
   git config --global --add safe.directory /workdir
   rm -rf /tmp/*
 EOF

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ You can use this image to produce binaries for multiple architectures.
 
 ## Supported targets
 
-| Triple               | Aliases                             | linux | freebsd |
-|----------------------|-------------------------------------|-------|---------|
-| x86_64-linux-gnu     | **(default)**, linux, amd64, x86_64 | ✔     |         |
-| arm-linux-gnueabihf  | armhf, armv7, armv7l                | ✔     |         |
-| aarch64-linux-gnu    | arm64, aarch64                      | ✔     |         |
-|  x86_64-pc-freebsd14 | freebsd                             |       |    ✔    |
+| Triple                                        | Aliases                             | linux   | freebsd |
+|-----------------------------------------------|-------------------------------------|---------|---------|
+| x86_64-linux-gnu, x86_64-linux-musl           | **(default)**, linux, amd64, x86_64 | ✔       |         |
+| arm-linux-gnueabihf, arm-linux-musleabihf     | armhf, armv7, armv7l                | ✔       |         |
+| aarch64-linux-gnu, aarch64-linux-musl         | arm64, aarch64                      | ✔       |         |
+| x86_64-pc-freebsd14                           | freebsd                             |         | ✔       |
 
 ## Using crossbuild
 


### PR DESCRIPTION
This change provides the ability to perform builds for all our binaries, archives and packages by utilising:
* GoReleaser
* musl cross-compiling toolchains

It also removes GOX and utilises the newer heredocs method for RUN statements inside the Dockerfile.
